### PR TITLE
Load scripts using https

### DIFF
--- a/client/mathjax.coffee
+++ b/client/mathjax.coffee
@@ -10,12 +10,12 @@ window.plugins.mathjax =
     typeset = ->
       window.MathJax.Hub.Queue ["Typeset", MathJax.Hub]
 
-    wiki.getScript 'http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML', typeset
+    wiki.getScript 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML', typeset
     div.append "<p>#{wiki.resolveLinks(item.text)}</p>"
 
   bind: (div, item) ->
     typeset = ->
       window.MathJax.Hub.Queue ["Typeset", MathJax.Hub, div.get(0)]
 
-    wiki.getScript 'http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML', typeset
+    wiki.getScript 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML', typeset
     div.dblclick -> wiki.textEditor div, item

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "grunt": "~0.4.x",
-    "grunt-contrib-coffee": "~0.13",
-    "grunt-contrib-watch": "~0.6",
-    "grunt-git-authors": "~3"
+    "grunt": "^1.0.1",
+    "grunt-contrib-coffee": "^1.0.0",
+    "grunt-contrib-watch": "^1.0.0",
+    "grunt-git-authors": "^3.2.0"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Use https url to load MathJax script - so loading does not fail if origin is itself using a https url

Also see https://github.com/fedwiki/wiki-client/pull/176